### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - hhvm
 
 matrix:
+  allow_failures:
+    - php: 7.0
   include:
     - php: 5.5
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,23 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 matrix:
   include:
-  - php: 5.5
-    env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: 5.5
+      env:
+        - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - PHPSPEC_FLAGS="-c phpspec.yml.ci"
+        - COVERAGE=true
 
-before_script:
+install:
   - travis_retry composer self-update
-  - if [[ "$TRAVIS_PHP_VERSION" == "hhvm" ]]; then composer remove "henrikbjorn/phpspec-code-coverage" --dev --no-update; fi
   - travis_retry composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction
 
-script:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then vendor/bin/phpspec run -c phpspec.yml.ci; fi
-  - if [[ "$TRAVIS_PHP_VERSION" == "hhvm" ]]; then vendor/bin/phpspec run; fi
+script: vendor/bin/phpspec run ${PHPSPEC_FLAGS}
 
 after_script:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml; fi
+  - if [[ "$COVERAGE" = true ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [[ "$COVERAGE" = true ]]; then php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml; fi


### PR DESCRIPTION
I did some experiments with travis and builds, especially with coverage reports. I found that There are several issues with HHVM and PHP 7.0 when it comes to code coverage. Then I realized that we probably don't need to generate coverage for all builds (since scrutinizer will only process the first).

So I came up with this config.

@boekkooi I would love to hear your opinion on this.
